### PR TITLE
Solves "wrong number of arguments (2 for 1) for `complement'" error when running sass

### DIFF
--- a/lib/preboot.scss
+++ b/lib/preboot.scss
@@ -41,7 +41,7 @@ $siteWidth:         ($gridColumns * $gridColumnWidth) + ($gridGutterWidth * ($gr
 
 // Color Scheme
 $baseColor:         $blue;                  // Set a base color
-$complement:        complement($baseColor, 180);  // Determine a complementary color
+$complement:        complement($baseColor);  // Determine a complementary color
 $split1:            adjust-hue($baseColor, 158);  // Split complements
 $split2:            adjust-hue($baseColor, -158);
 $triad1:            adjust-hue($baseColor, 135);  // Triads colors


### PR DESCRIPTION
See [sass complement documentation](http://sass-lang.com/docs/yardoc/Sass/Script/Functions.html#complement-instance_method).
