### PR TITLE
Fixed alert-message div's text color.

### DIFF
--- a/lib/patterns.scss
+++ b/lib/patterns.scss
@@ -499,9 +499,9 @@ footer {
   &.danger:hover,
   &.error,
   &.error:hover,
-  &.success
+  &.success,
   &.success:hover,
-  &.info
+  &.info,
   &.info:hover {
     color: $white;
   }


### PR DESCRIPTION
Added missing commas that were causing alert-message.success text to not be white.
