### PR TITLE
Legends in forms with .form-stacked

### DIFF
--- a/lib/forms.scss
+++ b/lib/forms.scss
@@ -437,7 +437,7 @@ textarea[readonly] {
     padding-top: $baseline / 2;
   }
   legend {
-    margin-left: 0;
+    padding-left: 0;
   }
   label {
     display: block;


### PR DESCRIPTION
The default styles for legends is to have a padding left of 150px. A form with the class "form-stacked" should reset the padding-left on the legends. The current style resets margin-left.
