### PR TITLE
Avoid fancy characters

### DIFF
--- a/lib/_forms.scss
+++ b/lib/_forms.scss
@@ -210,7 +210,7 @@ input[type="checkbox"]:focus {
 // Placeholder
 // -------------------------
 
-// Placeholder text gets special styles because when browsers invalidate entire lines if it doesn’t understand a selector
+// Placeholder text gets special styles because when browsers invalidate entire lines if it doesn't understand a selector
 input,
 textarea {
   @include placeholder();


### PR DESCRIPTION
This causes an error with sass (maybe I should update?) :

> Invalid US-ASCII character &quot;\xE2&quot;
