### PR TITLE
Fix dropdownLinkColorActive to match original twitter/bootstrap

### DIFF
--- a/lib/_variables.scss
+++ b/lib/_variables.scss
@@ -126,7 +126,7 @@ $dropdownDividerBottom:         $white !default;
 
 $dropdownLinkColor:             $grayDark !default;
 $dropdownLinkColorHover:        $white !default;
-$dropdownLinkColorActive:       $dropdownLinkColor !default;
+$dropdownLinkColorActive:       $white !default;
 
 $dropdownLinkBackgroundActive:  $linkColor !default;
 $dropdownLinkBackgroundHover:   $dropdownLinkBackgroundActive !default;


### PR DESCRIPTION
See https://github.com/twitter/bootstrap/blob/master/less/variables.less#L129 - must have been mistranslated. This was reported in thomas-mcdonald/bootstrap-sass#282
