### PR TITLE
fix :focus state in mixin buttonBackground

### DIFF
--- a/lib/_mixins.scss
+++ b/lib/_mixins.scss
@@ -244,7 +244,7 @@
 }
 
 // Drop shadows
-@mixin box-shadow($shadow...) { 
+@mixin box-shadow($shadow...) {
   -webkit-box-shadow: $shadow;
      -moz-box-shadow: $shadow;
           box-shadow: $shadow;
@@ -499,7 +499,7 @@
   @include reset-filter();
 
   // in these cases the gradient won't cover the background, so we override
-  &:hover, &:active, &.active, &.disabled, &[disabled] {
+  &:hover, &:focus, &:active, &.active, &.disabled, &[disabled] {
     color: $textColor;
     background-color: $endColor;
     *background-color: darken($endColor, 5%);


### PR DESCRIPTION
&:focus is missing on line 502, so buttons look broken on focus
![button focus bug](https://f.cloud.github.com/assets/419747/164024/203ce3ee-786f-11e2-9580-6167bf878cc0.png)
