### PR TITLE
Update component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -3,6 +3,6 @@
   "version": "2.3.1",
   "main": "lib/bootstrap.scss",
   "dependencies": {
-    "jquery": "~1.8.0"
+    "jquery": ">=1.8.0"
   }
 }


### PR DESCRIPTION
So bower stops overwriting jQuery 1.9.1 with 1.8.3
