### PR TITLE
3.0.0: Add secure source to Gemfile and Gemfile.lock 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'rake'
 gem 'sass', '~>3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     rake (10.0.4)
     rb-fsevent (0.9.3)

--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,7 @@ task BOOTSTRAP_MIN_CSS do |target|
 end
 
 
-desc "build regular and compresed versions of bootstrap"
+desc "build regular and compressed versions of bootstrap"
 task :build => [BOOTSTRAP_CSS, BOOTSTRAP_MIN_CSS]
 
 desc "rebuild regular version of bootstrap when modifications are made"


### PR DESCRIPTION
source :rubygems has been deprecated, as HTTP requests are insecure.

and minor typo fix.
