### PR TITLE
col-offset-* makes columns smaller instead of moving them

### DIFF
--- a/lib/_mixins.scss
+++ b/lib/_mixins.scss
@@ -512,7 +512,7 @@
 }
 
 @mixin col-offset-($columns, $grid-columns) {
-  width: percentage(($columns / $grid-columns));
+  margin-left: percentage(($columns / $grid-columns));
 }
 
 @mixin col-push-($columns, $grid-columns) {


### PR DESCRIPTION
prior to this patch col-offset-\* was applying a width instead of a
margin-left to divs making columns smaller instead of pushing them to
the right. Verified correct css from twitter/bootstrap repo:
twitter/bootstrap bootstrap.css on 3.0.0-wip branch starting at line 895

```
.col-offset-1 {
    margin-left: 8.333333333333332%;
  }
```
