### PR TITLE
Whitespace for parser

### DIFF
--- a/lib/_variables.scss
+++ b/lib/_variables.scss
@@ -289,13 +289,13 @@ $gridRowWidth768:         ($gridColumns * $gridColumnWidth768) + ($gridGutterWid
 
 // Fluid grid
 // -------------------------
-$fluidGridColumnWidth:    percentage($gridColumnWidth/$gridRowWidth) !default;
-$fluidGridGutterWidth:    percentage($gridGutterWidth/$gridRowWidth) !default;
+$fluidGridColumnWidth:    percentage($gridColumnWidth / $gridRowWidth) !default;
+$fluidGridGutterWidth:    percentage($gridGutterWidth / $gridRowWidth) !default;
 
 // 1200px min
-$fluidGridColumnWidth1200:     percentage($gridColumnWidth1200/$gridRowWidth1200) !default;
-$fluidGridGutterWidth1200:     percentage($gridGutterWidth1200/$gridRowWidth1200) !default;
+$fluidGridColumnWidth1200:     percentage($gridColumnWidth1200 / $gridRowWidth1200) !default;
+$fluidGridGutterWidth1200:     percentage($gridGutterWidth1200 / $gridRowWidth1200) !default;
 
 // 768px-979px
-$fluidGridColumnWidth768:      percentage($gridColumnWidth768/$gridRowWidth768) !default;
-$fluidGridGutterWidth768:      percentage($gridGutterWidth768/$gridRowWidth768) !default;
+$fluidGridColumnWidth768:      percentage($gridColumnWidth768 / $gridRowWidth768) !default;
+$fluidGridGutterWidth768:      percentage($gridGutterWidth768 / $gridRowWidth768) !default;


### PR DESCRIPTION
Adding whitespace on both sides of the division operator to avoid parsing errors with certain sass parsers.

Specifically the PHPSASS library https://github.com/richthegeek/phpsass
