### PR TITLE
Change /* */ comments by // and restore mini button

### DIFF
--- a/lib/_buttons.scss
+++ b/lib/_buttons.scss
@@ -126,11 +126,15 @@
   font-size: $font-size-large;
   border-radius: $border-radius-large;
 }
-.btn-small {
+.btn-small,
+.btn-mini {
   padding: $padding-small-vertical $padding-small-horizontal;
   font-size: $font-size-small;
   line-height: 1.5; // ensure proper height of button next to small input
   border-radius: $border-radius-small;
+}
+.btn-mini {
+  padding: 3px 5px;
 }
 
 

--- a/lib/_forms.scss
+++ b/lib/_forms.scss
@@ -118,14 +118,14 @@ textarea {
 input[type="radio"],
 input[type="checkbox"] {
   margin: 4px 0 0;
-  margin-top: 1px \9; /* IE8-9 */
+  margin-top: 1px \9; // IE8-9
   line-height: normal;
 }
 
 // Set the height of select and file controls to match text inputs
 select,
 input[type="file"] {
-  height: $input-height-base; /* In IE7, the height of the select element cannot be changed by height, only font-size. TODO: Check if this is still needed when dropping IE7 support */
+  height: $input-height-base; // In IE7, the height of the select element cannot be changed by height, only font-size. TODO: Check if this is still needed when dropping IE7 support
   line-height: $input-height-base;
 }
 

--- a/lib/_mixins.scss
+++ b/lib/_mixins.scss
@@ -19,8 +19,8 @@
 @mixin clearfix() {
   &:before,
   &:after {
-    content: " "; /* 1 */
-    display: table; /* 2 */
+    content: " "; // 1
+    display: table; // 2
   }
   &:after {
     clear: both;


### PR DESCRIPTION
/\* */ comments can cause parsing problems with CSS Parse & Rework.
Restore mini button
