### PR TITLE
Fixed input form validation states

### DIFF
--- a/lib/_mixins.scss
+++ b/lib/_mixins.scss
@@ -579,7 +579,7 @@
     color: $text-color;
   }
   // Set the border and box shadow on specific inputs to match
-  .input-with-feedback {
+  .form-control {
     padding-right: 32px; // to account for the feedback icon
     border-color: $border-color;
     @include box-shadow(inset 0 1px 1px rgba(0,0,0,.075)); // Redeclare so transitions work


### PR DESCRIPTION
The mixin was incorrect for 3.0.0 with using the old `input-with-feedback` class - Bootstrap changed it to just use the `form-control` class
