### PR TITLE
remove jquery dependency

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,8 +1,5 @@
 {
   "name": "sass-bootstrap",
   "version": "2.3.2",
-  "main": "lib/bootstrap.scss",
-  "dependencies": {
-    "jquery": ">=1.8.0"
-  }
+  "main": "lib/bootstrap.scss"
 }


### PR DESCRIPTION
Not all users need JQuery to achieve bootstrap's javascript functionality. They could be using https://github.com/angular-ui/bootstrap instead for example. This change leaves it up to the user to specify the JQuery dependency if she needs it.
