### PR TITLE
Badge Color Variations

### DIFF
--- a/lib/_badges.scss
+++ b/lib/_badges.scss
@@ -49,3 +49,31 @@ a.list-group-item.active > .badge,
 .nav-pills > li > a > .badge {
   margin-left: 3px;
 }
+
+.badge-default {
+  @include color-variant($badge-default-bg);
+}
+
+.badge-primary {
+  @include color-variant($badge-primary-bg);
+}
+
+.badge-success {
+  @include color-variant($badge-success-bg);
+}
+
+.badge-info {
+  @include color-variant($badge-info-bg);
+}
+
+.badge-warning {
+  @include color-variant($badge-warning-bg);
+}
+
+.badge-danger {
+  @include color-variant($badge-danger-bg);
+}
+
+.badge-inverse {
+  @include color-variant($badge-inverse-bg);
+}

--- a/lib/_labels.scss
+++ b/lib/_labels.scss
@@ -34,25 +34,25 @@
 // Contextual variations (linked labels get darker on :hover)
 
 .label-default {
-  @include label-variant($label-default-bg);
+  @include color-variant($label-default-bg);
 }
 
 .label-primary {
-  @include label-variant($label-primary-bg);
+  @include color-variant($label-primary-bg);
 }
 
 .label-success {
-  @include label-variant($label-success-bg);
+  @include color-variant($label-success-bg);
 }
 
 .label-info {
-  @include label-variant($label-info-bg);
+  @include color-variant($label-info-bg);
 }
 
 .label-warning {
-  @include label-variant($label-warning-bg);
+  @include color-variant($label-warning-bg);
 }
 
 .label-danger {
-  @include label-variant($label-danger-bg);
+  @include color-variant($label-danger-bg);
 }

--- a/lib/_mixins.scss
+++ b/lib/_mixins.scss
@@ -475,9 +475,9 @@
   }
 }
 
-// Labels
+// Labels and Badges
 // -------------------------
-@mixin label-variant($color) {
+@mixin color-variant($color) {
   background-color: $color;
   &[href] {
     &:hover,

--- a/lib/_variables.scss
+++ b/lib/_variables.scss
@@ -536,6 +536,15 @@ $well-bg:                     #f5f5f5 !default;
 
 // Badges
 // -------------------------
+
+$badge-default-bg:            $gray-light !default;
+$badge-primary-bg:            $brand-primary !default;
+$badge-success-bg:            $brand-success !default;
+$badge-info-bg:               $brand-info !default;
+$badge-warning-bg:            $brand-warning !default;
+$badge-danger-bg:             $brand-danger !default;
+$badge-inverse-bg:            $gray-dark !default;
+
 $badge-color:                 #fff !default;
 $badge-link-hover-color:      #fff !default;
 $badge-bg:                    $gray-light !default;


### PR DESCRIPTION
This branch adds back the color variants that were part of the badges in previous versions of twitter bootstrap.  It makes use of the same mixin that was used for the label variations.
