### PR TITLE
Issue compiling with embedded variables

### DIFF
--- a/lib/_glyphicons.scss
+++ b/lib/_glyphicons.scss
@@ -10,11 +10,11 @@
 // Import the fonts
 @font-face {
   font-family: 'Glyphicons Halflings';
-  src: url('#{$icon-font-path}#{$icon-font-name}.eot');
-  src: url('#{$icon-font-path}#{$icon-font-name}.eot?#iefix') format('embedded-opentype'),
-       url('#{$icon-font-path}#{$icon-font-name}.woff') format('woff'),
-       url('#{$icon-font-path}#{$icon-font-name}.ttf') format('truetype'),
-       url('#{$icon-font-path}#{$icon-font-name}.svg#glyphicons-halflingsregular') format('svg');
+  src: url($icon-font-path + $icon-font-name + ".eot");
+  src: url($icon-font-path + $icon-font-name + ".eot?#iefix") format('embedded-opentype'),
+       url($icon-font-path + $icon-font-name + ".woff") format('woff'),
+       url($icon-font-path + $icon-font-name + ".ttf") format('truetype'),
+       url($icon-font-path + $icon-font-name + ".svg#glyphicons-halflingsregular") format('svg');
 }
 
 // Catchall baseclass


### PR DESCRIPTION
I'm not sure why, but my installation of compass seems entirely unprepared to deal with the formats of these particular strings.

Provided it's backwards compatible with currently supported compilers, can we keep it? :)
