### PR TITLE
Fix double comma in selector

### DIFF
--- a/lib/_mixins.scss
+++ b/lib/_mixins.scss
@@ -724,7 +724,7 @@
     $list: ".col-xs-#{$i}, .col-sm-#{$i}, .col-md-#{$i}, .col-lg-#{$i}, #{$list}";
   }
   $i: $grid-columns;
-  $list: "#{$list}, .col-xs-#{$i}, .col-sm-#{$i}, .col-md-#{$i}, .col-lg-#{$i}";
+  $list: "#{$list} .col-xs-#{$i}, .col-sm-#{$i}, .col-md-#{$i}, .col-lg-#{$i}";
   #{$list} {
     position: relative;
     // Prevent columns from collapsing when empty
@@ -743,7 +743,7 @@
     $list: ".col-#{$class}-#{$i}, #{$list}";
   }
   $i: $grid-columns;
-  $list: "#{$list}, .col-#{$class}-#{$i}";
+  $list: "#{$list} .col-#{$class}-#{$i}";
   #{$list} {
     float: left;
   }


### PR DESCRIPTION
In make-grid-columns() and make-grid-columns-float() mixins there was a double comma in the list of selectors ($list). This was fine for Ruby sass compiler, but libsass didn't accept it.

Fixes issue #117.
