### PR TITLE
Uglifier JS compressor blows up with missing ;

### DIFF
--- a/js/alert.js
+++ b/js/alert.js
@@ -23,7 +23,7 @@
   // ALERT CLASS DEFINITION
   // ======================
 
-  var dismiss = '[data-dismiss="alert"]'
+  var dismiss = '[data-dismiss="alert"]';
   var Alert   = function (el) {
     $(el).on('click', dismiss, this.close)
   }


### PR DESCRIPTION
I was getting a JS error from this file but only when it's compressed.  I added in the semicolon and the error goes away.  The error was an unexpected var.  This might actually be an issue with uglifier, I'm not sure, but I figure even if it is, it's an easy enough fix here that I should just add it in.
